### PR TITLE
Update README to reflect the fog-arubacloud repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ TODO: Write usage instructions here
 
 ## Contributing
 
-1. Fork it ( http://github.com/fog/fog-arubacloud/fork )
+1. Fork it ( https://github.com/fog/fog-arubacloud/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ TODO: Write usage instructions here
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/fog-arubacloud/fork )
+1. Fork it ( http://github.com/fog/fog-arubacloud/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
-# fog-arubacloud
+5. Create new Pull Request


### PR DESCRIPTION
Just a small fix for the README.
